### PR TITLE
fix: map axios responseType to correct Response method name

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -23,7 +23,8 @@ async function prepareAxiosResponse(
 		response.data = res.body;
 		return response;
 	}
-	return res[options.responseType || "text"]()
+	const method = options.responseType === "arraybuffer" ? "arrayBuffer" : (options.responseType || "text");
+	return res[method]()
 		.then((data) => {
 			if (options.transformResponse) {
 				Array.isArray(options.transformResponse)

--- a/test/client.spec.ts
+++ b/test/client.spec.ts
@@ -21,12 +21,18 @@ const posts = [
 		body: "first post body",
 	},
 ];
+const binaryPayload = new Uint8Array([0x00, 0x01, 0x02, 0x03]);
 const restHandlers = [
 	http.get("http://test.com", () => {
 		return HttpResponse.json(posts);
 	}),
 	http.get("http://test1.com", () => {
 		return HttpResponse.text("hello");
+	}),
+	http.get("http://test1.com/binary", () => {
+		return new HttpResponse(binaryPayload, {
+			headers: { "content-type": "application/octet-stream" },
+		});
 	}),
 	http.post("http://test1.com/post", (c) => {
 		return new HttpResponse(c.request.body, { status: 200 });
@@ -109,6 +115,14 @@ describe("feaxios", () => {
 				responseType: "text",
 			});
 			expect(res.data).toEqual(posts);
+		});
+
+		it("should return ArrayBuffer for responseType:arraybuffer", async () => {
+			const res = await axios.get(`${testHost}/binary`, {
+				responseType: "arraybuffer",
+			});
+			expect(res.data).toBeInstanceOf(ArrayBuffer);
+			expect(new Uint8Array(res.data)).toEqual(binaryPayload);
 		});
 	});
 


### PR DESCRIPTION
## Problem

Using `responseType: "arraybuffer"` throws:

```
AxiosError: res[(options.responseType || "text")] is not a function
```

The current code calls `res[options.responseType || "text"]()` directly on the Fetch API `Response` object. Axios uses `"arraybuffer"` (lowercase) but the Fetch API method is `arrayBuffer()` (camelCase), so `res["arraybuffer"]` is `undefined`.

## Fix

Map `"arraybuffer"` to `"arrayBuffer"` before calling the method on `Response`.

## Test

Added a test case that sends a binary response and requests it with `responseType: "arraybuffer"`. Without the fix it throws the error above; with the fix it returns an `ArrayBuffer` as expected.